### PR TITLE
Make sure the password dialog widget gets created on the main thread.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,4 +184,11 @@ if(APPLE)
 
   set(CPACK_GENERATOR "DRAGNDROP")
   include(CPack)
+elseif(WIN32)
+  set_target_properties(
+    "${PROJECT_NAME}"
+    PROPERTIES
+      RESOURCE "${RESOURCE_FILES}"
+      WIN32_EXECUTABLE TRUE
+  )
 endif()

--- a/src/app/imp.hpp
+++ b/src/app/imp.hpp
@@ -7,6 +7,8 @@
 
 #include "app.hpp"  // IWYU pragma: associated
 
+#include <future>
+
 namespace metier
 {
 class OTWrap;
@@ -17,7 +19,9 @@ namespace metier
 struct App::Imp {
     static std::unique_ptr<App> singleton_;
 
-    bool init_{false};
+    std::atomic_bool init_{false};
+    std::promise<void> init_promise_{};
+    std::future<void> init_future_{init_promise_.get_future()};
 
     static auto factory(App& parent, int& argc, char** argv) noexcept
         -> std::unique_ptr<Imp>;

--- a/src/widgets/mainwindow/syncprogress.hpp
+++ b/src/widgets/mainwindow/syncprogress.hpp
@@ -34,8 +34,13 @@ struct SyncProgress {
 
     auto update(const ot::blockchain::Type chain, const Progress value) noexcept
     {
-        ot::Lock lock{lock_};
-        progress_[chain] = value;
+        try {
+            ot::Lock lock{lock_};
+
+            progress_[chain] = value;
+        } catch ([[maybe_unused]] const std::system_error& e) {
+            return;
+        }
     }
 
     SyncProgress() noexcept


### PR DESCRIPTION
Prevent a mutex exception when shutting down the gui.