### PR TITLE
OT-103 - change required by qml password prompt temporary implemention

### DIFF
--- a/src/app/qml.cpp
+++ b/src/app/qml.cpp
@@ -6,7 +6,7 @@
 #include "app/imp.hpp"  // IWYU pragma: associated
 
 #include <opentxs/opentxs.hpp>
-#include <QGuiApplication>
+#include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QQuickView>
@@ -25,7 +25,7 @@
 
 namespace metier
 {
-struct QmlApp final : public App::Imp, public QGuiApplication {
+struct QmlApp final : public App::Imp, public QApplication {
 private:
     std::promise<void> model_promise_;
 
@@ -158,7 +158,7 @@ public:
     auto otwrap() noexcept -> Api* final { return ot_.get(); }
 
     QmlApp(App& parent, int& argc, char** argv) noexcept
-        : QGuiApplication(argc, argv)
+        : QApplication(argc, argv)
         , model_promise_()
         , parent_(parent)
         , ot_()


### PR DESCRIPTION
OT-103 implements password prompt dialog temporary based on legacy ui+QWidgets at qml initialization. Using QWidgets requires upgrading QGuiApplication to QApplication. 
This change will be removed when legacy implementation will be promoted to fully qml implementation.